### PR TITLE
test: usa sqlite in-memory e valida gravação com persistencia no banco

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,8 +4,20 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
+from sqlmodel import Session, SQLModel, create_engine, select
 
 from app.app import app
+from app.database import get_session
+from app.models.ticket import Ticket
+
+engine_test = create_engine(
+    'sqlite://', connect_args={'check_same_thread': False}
+)
+
+
+def sbrescrever_get_session():
+    with Session(engine_test) as session:
+        yield session
 
 
 def test_health_app():
@@ -18,6 +30,9 @@ def test_health_app():
 
 @pytest.mark.anyio
 async def test_add_ticket_app_sucesso():
+    SQLModel.metadata.create_all(engine_test)
+    app.dependency_overrides[get_session] = sbrescrever_get_session
+
     targ = 'app.app.client.aio.models.generate_content'
     mock_response = AsyncMock()
     mock_response.text = (
@@ -34,17 +49,28 @@ async def test_add_ticket_app_sucesso():
             response = await ac.post('/v1/tickets/', json=payload)
 
     data = response.json()
-
     assert response.status_code == HTTPStatus.CREATED
     assert 'id' in data['dados_originais']
     assert 'criado_em' in data['dados_originais']
-    assert 'prioridade' in data['dados_originais']
-    assert 'categoria' in data['classe']
-    assert 'urgencia' in data['classe']
+    assert data['classe']['categoria'] == 'Dúvida'
+
+    with Session(engine_test) as session:
+        search = select(Ticket).where(Ticket.titulo == payload['titulo'])
+        ticket = session.exec(search).first()
+
+        assert ticket is not None
+        assert ticket.id == 1
+        assert ticket.categoria == 'Dúvida'
+
+    app.dependency_overrides.clear()
+    SQLModel.metadata.drop_all(engine_test)
 
 
 @pytest.mark.anyio
 async def test_add_ticket_ai_falha():
+    SQLModel.metadata.create_all(engine_test)
+    app.dependency_overrides[get_session] = sbrescrever_get_session
+
     target = 'app.app.client.aio.models.generate_content'
     with patch(target, new_callable=AsyncMock) as mock_ai:
         mock_ai.side_effect = Exception('Erro de conexão com o Google')
@@ -60,9 +86,17 @@ async def test_add_ticket_ai_falha():
     assert response.status_code == HTTPStatus.CREATED
     assert response.json()['classe']['categoria'] == 'Não classificado'
 
+    with Session(engine_test) as session:
+        ticket = session.exec(select(Ticket)).first()
+        assert ticket is not None
+        assert ticket.categoria == 'Erro'
+
+    app.dependency_overrides.clear()
+    SQLModel.metadata.drop_all(engine_test)
+
 
 def test_add_ticket_app_error():
     client = TestClient(app)
-
     response = client.post('/v1/tickets/')
+
     assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY


### PR DESCRIPTION
Implementa sobrescrita de dependência para usar SQLite in-memory nos testes

Adicionada verificação de persistência real no banco de dados após as requisições

Refatorados testes de sucesso e falha da IA para garantir independência do ambiente Docker